### PR TITLE
Add missing mkdocstrings dependency; bump kghub-downloader

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 python = "^{{cookiecutter.min_python_version}}"
 importlib-metadata = ">=4.8.0"
 koza = ">=0.6.0"
-kghub-downloader = ">=0.3.8"
+kghub-downloader = ">=0.3.11"
 kgx = ">=2.4.0"
 biolink-model = "^4.2.0"
 duckdb = ">=0.10.2"
@@ -22,6 +22,7 @@ optional = true
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8.1.1"
 mkdocs = ">=1.4"
+mkdocstrings = { extras=["python"], version=">=0.26.2" }
 mkdocs-material = ">=9.5"
 mkdocs-macros-plugin = "*"
 black = "*"


### PR DESCRIPTION
With https://github.com/monarch-initiative/kghub-downloader/pull/45 and `kghub-downloader@0.3.11`, `mkdocs` and plugins are moved to that package's dev dependencies. This PR installs that version of `kghub-downloader` and adds a missing `mkdocstrings` dependency that had previously been pulled in transitively.

Fixes #10.