### PR TITLE
Use download options

### DIFF
--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.__project_slug}}/cli.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.__project_slug}}/cli.py
@@ -4,6 +4,7 @@ import logging
 from pathlib import Path
 
 from kghub_downloader.download_utils import download_from_yaml
+from kghub_downloader.model import DownloadOptions
 from koza.cli_utils import transform_source
 import typer
 
@@ -24,10 +25,12 @@ def callback(version: bool = typer.Option(False, "--version", is_eager=True),
 @app.command()
 def download(force: bool = typer.Option(False, help="Force download of data, even if it exists")):
     """Download data for {{cookiecutter.project_name}}."""
-    typer.echo("Downloading data for {{cookiecutter.project_name}}...")
+    typer.echo("Downloading data for {{cookiecutter.project_name}}...")    
     download_config = Path(__file__).parent / "download.yaml"
-    download_from_yaml(yaml_file=download_config, output_dir=".", ignore_cache=force)
-
+    download_options = DownloadOptions(ignore_cache=force)
+    download_from_yaml(yaml_file=download_config,
+                       output_dir=".",
+                       download_options=download_options)
 
 @app.command()
 def transform(


### PR DESCRIPTION
Updates the cookiecutter cli to use download_options rather than sending a bare param
