### PR TITLE
Upgrade cookiecutter template to koza 2.x

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^{{cookiecutter.min_python_version}}"
 importlib-metadata = ">=4.8.0"
-koza = ">=0.6.0"
+koza = "^2.0.0"
 kghub-downloader = ">=0.3.11"
 kgx = ">=2.4.0"
 biolink-model = "^4.2.0"

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.__project_slug}}/transform.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.__project_slug}}/transform.py
@@ -1,13 +1,39 @@
-import uuid  # For generating UUIDs for associations
+"""
+Transform for {{ cookiecutter.project_name }}.
 
-from biolink_model.datamodel.pydanticmodel_v2 import *  # Replace * with any necessary data classes from the Biolink Model
-from koza.cli_utils import get_koza_app
+This module transforms data from the source into Biolink model entities and associations.
+"""
 
-koza_app = get_koza_app("{{cookiecutter.__ingest_name}}")
+import uuid
+from typing import Any
 
-while (row := koza_app.get_row()) is not None:
-    # Code to transform each row of data
-    # For more information, see https://koza.monarchinitiative.org/Ingests/transform
+import koza
+from koza import KozaTransform
+from biolink_model.datamodel.pydanticmodel_v2 import Entity, Association
+
+
+@koza.transform_record()
+def transform_record(koza_transform: KozaTransform, row: dict[str, Any]) -> list[Entity | Association]:
+    """
+    Transform a data row into Biolink entities and associations.
+
+    Args:
+        koza_transform: Koza transform context
+        row: Dictionary containing row data
+
+    Returns:
+        list[Entity | Association]: List of Biolink entities and/or associations
+
+    Note:
+        - Always return a list, even for single entities
+        - Return empty list [] to skip rows (don't return None)
+        - Import specific Biolink classes instead of using *
+    """
+    # Example: Skip rows without required data
+    if not row.get('example_column_1') or not row.get('example_column_2'):
+        return []
+
+    # Example entities
     entity_a = Entity(
         id=f"XMPL:00000{row['example_column_1'].split('_')[-1]}",
         name=row["example_column_1"],
@@ -18,8 +44,10 @@ while (row := koza_app.get_row()) is not None:
         name=row["example_column_2"],
         category=["biolink:Entity"],
     )
+
+    # Example association
     association = Association(
-        id=str(uuid.uuid1()),
+        id=f"uuid:{uuid.uuid4()}",  # Use uuid4() for association IDs
         subject=row["example_column_1"],
         predicate=row["example_column_3"],
         object=row["example_column_2"],
@@ -29,4 +57,5 @@ while (row := koza_app.get_row()) is not None:
         knowledge_level="not_provided",
         agent_type="not_provided",
     )
-    koza_app.write(entity_a, entity_b, association)
+
+    return [entity_a, entity_b, association]

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.__project_slug}}/transform.yaml
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.__project_slug}}/transform.yaml
@@ -1,60 +1,62 @@
 # Config file for transforming data from a source
 # See additional/optional config parameters at https://koza.monarchinitiative.org/Ingests/source_config/
+#
+# This uses Koza 2.x nested configuration format with reader/transform/writer sections
 
 name: "{{ cookiecutter.__ingest_name }}"
-metadata: "./src/{{cookiecutter.__project_slug}}/metadata.yaml"
-format: "csv" # Format of the data files (csv or json)
-files:
-  - "./data/example_data.tsv"
-#################################################################################################
-### file_archive is typically optional, but required if:                                      ###
-###    1. files is not provided                                                               ###
-###    2. files listed above are compressed in an archive such as a tarball or zip file       ###
-### If you have a file archive, uncomment the line below and provide the path to the archive  ###
-### Otherwise, it is safe to remove this section and the file_archive parameter               ###
-#################################################################################################
-# file_archive: Optional path to a file archive containing files to process
 
-node_properties:
-  # List of node properties to include, if ingesting nodes
-  # Remove if not ingesting nodes
-  - id
-  - name
-  - category
+reader:
+  format: "csv"  # Format of the data files (csv or json)
+  files:
+    - "../../data/example_data.tsv"
+  #################################################################################################
+  ### file_archive is typically optional, but required if:                                      ###
+  ###    1. files is not provided                                                               ###
+  ###    2. files listed above are compressed in an archive such as a tarball or zip file       ###
+  ### If you have a file archive, uncomment the line below and provide the path to the archive  ###
+  ### Otherwise, it is safe to remove this section and the file_archive parameter               ###
+  #################################################################################################
+  # file_archive: Optional path to a file archive containing files to process
 
-edge_properties:
-  # List of edge properties to include if ingesting edges
-  # Remove if not ingesting edges
-  - id
-  - subject
-  - predicate
-  - object
-  - subject_category
-  - object_category
-  - category
-  - knowledge_level
-  - agent_type
+  delimiter: "\t"  # Delimiter for csv files (REQUIRED if format is csv)
+  # columns: List of columns to include
+  # field_type_map: Dict of field names and their type (using the FieldType enum)
+  # required_properties: List of properties which must be in json data files
+  # header_mode: Header row mode (infer, none, or line number)
+  # header_delimiter: Delimiter for header in csv files
+  # header_prefix: Prefix for header in csv files
+  # comment_char: Comment character for csv files (default: #)
+  # skip_blank_lines: Boolean - whether to skip blank lines (default: true)
+  # json_path: List of paths within JSON object containing data to process
 
-### Optional parameters - uncomment to use, or remove to ignore
+transform:
+  code: "./transform.py"  # Path to transform code
+  # filters: List of filters to apply
+  # mapping: List of dependency configs this transform depends on
+  # global_table: Path to a global table file
+  # local_table: Path to a local table file
 
-min_node_count: 10
-min_edge_count: 5
-# sssom_config: List of SSSOM config options
-# field_type_map: Dict of field names and their type (using the FieldType enum)
-# filters: List of filters to apply
-# required_properties: List of properties which must be in json data files
-# json_path: List of paths within JSON object containing data to process
-# transform_code: Path to a python file to transform the data
-# transform_mode: Which mode to use to process the transform file
-# global_table: Path to a global table file
-# local_table: Path to a local table file
+writer:
+  node_properties:
+    # List of node properties to include, if ingesting nodes
+    # Remove this section if not ingesting nodes
+    - id
+    - name
+    - category
 
-### CSV specific parameters
+  edge_properties:
+    # List of edge properties to include if ingesting edges
+    # Remove this section if not ingesting edges
+    - id
+    - subject
+    - predicate
+    - object
+    - subject_category
+    - object_category
+    - category
+    - knowledge_level
+    - agent_type
 
-delimiter: "\t" # Delimiter for csv files (REQUIRED if format is csv)
-# columns: List of columns to include in output
-# header: Header row index
-# header_delimiter: Delimiter for header in csv files
-# header_prefix: Prefix for header in csv files
-# comment_char: Comment character for csv files
-# skip_blank_lines: Boolean - whether to skip blank lines in csv files
+  min_node_count: 10
+  min_edge_count: 5
+  # sssom_config: SSSOM config options

--- a/{{cookiecutter.project_name}}/tests/test_example.py
+++ b/{{cookiecutter.project_name}}/tests/test_example.py
@@ -1,7 +1,7 @@
 """
 An example test file for the transform script.
 
-It uses pytest fixtures to define the input data and the mock koza transform.
+It uses pytest fixtures to define the input data and the KozaRunner.
 The test_example function then tests the output of the transform script.
 
 See the Koza documentation for more information on testing transforms:
@@ -10,11 +10,24 @@ https://koza.monarchinitiative.org/Usage/testing/
 
 import pytest
 
-from koza.utils.testing_utils import mock_koza
+from biolink_model.datamodel.pydanticmodel_v2 import Association, Entity
+from koza.io.writer.writer import KozaWriter
+from koza.runner import KozaRunner, KozaTransformHooks
 
-# Define the ingest name and transform script path
-INGEST_NAME = "{{cookiecutter.__ingest_name}}"
-TRANSFORM_SCRIPT = "./src/{{cookiecutter.__project_slug}}/transform.py"
+from {{cookiecutter.__project_slug}}.transform import transform_record
+
+
+class MockWriter(KozaWriter):
+    """Mock writer for testing that captures written entities."""
+
+    def __init__(self):
+        self.items = []
+
+    def write(self, entities):
+        self.items += entities
+
+    def finalize(self):
+        pass
 
 
 # Define an example row to test (as a dictionary)
@@ -46,25 +59,32 @@ def example_list_of_rows():
 
 # Define the mock koza transform
 @pytest.fixture
-def mock_transform(mock_koza, example_row):
-    # Returns [entity_a, entity_b, association] for a single row
-    return mock_koza(
-        INGEST_NAME,
-        example_row,
-        TRANSFORM_SCRIPT,
+def mock_transform(example_row):
+    """Run transform on a single row and return results."""
+    writer = MockWriter()
+
+    runner = KozaRunner(
+        data=iter([example_row]),
+        writer=writer,
+        hooks=KozaTransformHooks(transform_record=[transform_record])
     )
+    runner.run()
+    return writer.items
 
 
 # Or for multiple rows
 @pytest.fixture
-def mock_transform_multiple_rows(mock_koza, example_list_of_rows):
-    # Returns concatenated list of [entity_a, entity_b, association]
-    # for each row in example_list_of_rows
-    return mock_koza(
-        INGEST_NAME,
-        example_list_of_rows,
-        TRANSFORM_SCRIPT,
+def mock_transform_multiple_rows(example_list_of_rows):
+    """Run transform on multiple rows and return concatenated results."""
+    writer = MockWriter()
+
+    runner = KozaRunner(
+        data=iter(example_list_of_rows),
+        writer=writer,
+        hooks=KozaTransformHooks(transform_record=[transform_record])
     )
+    runner.run()
+    return writer.items
 
 
 # Test the output of the transform
@@ -72,14 +92,34 @@ def mock_transform_multiple_rows(mock_koza, example_list_of_rows):
 
 def test_single_row(mock_transform):
     assert len(mock_transform) == 3
-    entity = mock_transform[0]
-    assert entity
-    assert entity.name == "entity_1"
+
+    # Check entity types
+    entity_a = mock_transform[0]
+    entity_b = mock_transform[1]
+    association = mock_transform[2]
+
+    assert isinstance(entity_a, Entity)
+    assert isinstance(entity_b, Entity)
+    assert isinstance(association, Association)
+
+    # Check entity properties
+    assert entity_a.name == "entity_1"
+    assert entity_b.name == "entity_6"
+    assert association.predicate == "biolink:related_to"
 
 
 def test_multiple_rows(mock_transform_multiple_rows):
-    assert len(mock_transform_multiple_rows) == 6
+    assert len(mock_transform_multiple_rows) == 6  # 3 entities per row × 2 rows
+
+    # Check first row entities
     entity_a = mock_transform_multiple_rows[0]
     entity_b = mock_transform_multiple_rows[1]
+    association = mock_transform_multiple_rows[2]
+
+    assert isinstance(entity_a, Entity)
+    assert isinstance(entity_b, Entity)
+    assert isinstance(association, Association)
+
     assert entity_a.name == "entity_1"
     assert entity_b.name == "entity_6"
+    assert association.predicate == "biolink:related_to"


### PR DESCRIPTION
## Summary

This PR upgrades the cookiecutter-monarch-ingest template to use koza 2.x, implementing the new API patterns introduced in koza 2.0.

### Key Changes

#### Configuration Changes (transform.yaml)
- ✅ Restructured to nested format with `reader`/`transform`/`writer` sections
- ✅ Moved files, format, delimiter into `reader` section
- ✅ Added `transform` section with code path
- ✅ Moved node_properties, edge_properties into `writer` section
- ✅ Updated file paths to be relative to YAML location (`../../data/`)

#### Python Transform Changes (transform.py)
- ✅ Replaced loop-based pattern (`get_koza_app()`) with decorator-based pattern
- ✅ Added `@koza.transform_record()` decorator
- ✅ Changed to `transform_record()` function with proper type hints
- ✅ Return list of entities instead of using `koza_app.write()`
- ✅ Use `uuid.uuid4()` instead of `uuid.uuid1()`
- ✅ Added comprehensive docstrings and examples

#### CLI Changes (cli.py)
- ✅ Replaced `transform_source` with `KozaRunner.from_config_file()`
- ✅ Changed output_format from string to `OutputFormat` enum
- ✅ Added `show_progress` parameter for progress bar support

#### Test Changes (test_example.py)
- ✅ Removed deprecated `mock_koza` import
- ✅ Added `KozaRunner`, `KozaTransformHooks`, `KozaWriter` imports
- ✅ Created `MockWriter` class for testing
- ✅ Updated fixtures to use new testing patterns
- ✅ Import `transform_record` directly from transform module
- ✅ Added type checking assertions

#### Dependency Changes (pyproject.toml)
- ✅ Updated koza dependency from `>=0.6.0` to `^2.0.0`

### Migration Impact

Projects generated from this template will now:
- Use the modern koza 2.x decorator-based API
- Have properly structured configuration files with nested sections
- Include improved type hints and documentation
- Follow current best practices for koza transforms

### Breaking Changes

This template now requires koza 2.x. New projects generated from this template will not be compatible with koza 1.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)