### PR TITLE
Update koza minimum version to 2.x

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -15,7 +15,7 @@ requires-python = ">=3.10,<4.0"
 dynamic = ["version"]
 
 dependencies = [
-  "koza>=0.6.0",
+  "koza>=2.0.0",
   "biolink-model>=4.0.0",
 ]
 


### PR DESCRIPTION
## Summary
- Update koza dependency minimum from `>=0.6.0` to `>=2.0.0` in the template

## Test plan
- Verify new projects generated from this template require koza 2.x