### PR TITLE
Bump actions/checkout from v4 to v5

### DIFF
--- a/.claude/skills/migrate-standalone-ingest.md
+++ b/.claude/skills/migrate-standalone-ingest.md
@@ -461,7 +461,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4

--- a/template/.github/workflows/release.yaml
+++ b/template/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4

--- a/template/.github/workflows/test.yaml
+++ b/template/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4


### PR DESCRIPTION
## Summary
- Bump `actions/checkout@v4` → `@v5` in `template/.github/workflows/{test,release}.yaml`
- Update the `migrate-standalone-ingest` skill example to match

Ingests using this template will pick this up on their next `copier update`.

## Test plan
- [ ] CI passes on a downstream ingest after `copier update`